### PR TITLE
Mark all search terms as sanitary that appear in Ad Marketplace Allow List

### DIFF
--- a/nightly-job/nightly-sanitization-pipeline.ipynb
+++ b/nightly-job/nightly-sanitization-pipeline.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "ffc5aca5-bb6f-43ee-b865-a971ad38edc8",
    "metadata": {
     "tags": []
@@ -57,477 +57,6 @@
      "text": [
       "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
      ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], []]\n",
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n",
-      "New row representing job run successfully added.\n"
-     ]
     }
    ],
    "source": [
@@ -536,53 +65,60 @@
     "\n",
     "start_time = datetime.utcnow()\n",
     "\n",
-    "try:\n",
-    "    total_run = 0\n",
-    "    total_allow_listed = 0\n",
-    "    total_deemed_sanitary = 0\n",
-    "    summary_run_data = {}\n",
-    "    summary_language_data = {}\n",
-    "    yesterday = datetime.utcnow().date() - timedelta(days=1)\n",
-    "    \n",
-    "    data_validation_sample = pd.DataFrame()\n",
-    "    \n",
-    "    unsanitized_search_term_stream = stream_search_terms() # load unsanitized search terms\n",
-    "    for raw_page in unsanitized_search_term_stream:\n",
-    "        total_run += raw_page.shape[0]\n",
-    "        \n",
-    "        one_percent_sample = raw_page.sample(frac = 0.01)\n",
-    "        data_validation_sample = data_validation_sample.append(one_percent_sample)\n",
-    "        \n",
-    "        allow_listed_terms_page = raw_page.loc[raw_page.present_in_allow_list]\n",
-    "        unsanitized_unallowlisted_terms = raw_page.loc[~raw_page.present_in_allow_list]\n",
+    "async def run_sanitation(args):\n",
+    "    start_time = datetime.utcnow()\n",
     "\n",
-    "        pii_in_query_mask, run_data, language_data = await detect_pii(unsanitized_unallowlisted_terms['query'], census_surnames)\n",
-    "        sanitized_page = unsanitized_unallowlisted_terms.loc[~numpy.array(pii_in_query_mask)] # ~ reverses the mask so we get the queries WITHOUT PII in them\n",
-    "        total_allow_listed += allow_listed_terms_page.shape[0]\n",
-    "        total_deemed_sanitary += (sanitized_page.shape[0] + total_allow_listed)\n",
+    "    try:\n",
+    "        total_run = 0\n",
+    "        total_allow_listed = 0\n",
+    "        total_cleared_in_sanitation = 0\n",
+    "        summary_run_data = {}\n",
+    "        summary_language_data = {}\n",
+    "        yesterday = datetime.utcnow().date() - timedelta(days=1)\n",
+    "    \n",
+    "        data_validation_sample = pd.DataFrame()\n",
+    "    \n",
+    "        unsanitized_search_term_stream = stream_search_terms() # load unsanitized search terms\n",
+    "        for raw_page in unsanitized_search_term_stream:\n",
+    "            total_run += raw_page.shape[0]\n",
     "        \n",
-    "        summary_language_data = dict(functools.reduce(operator.add,\n",
+    "            one_percent_sample = raw_page.sample(frac = 0.01)\n",
+    "            data_validation_sample = data_validation_sample.append(one_percent_sample)\n",
+    "        \n",
+    "            allow_listed_terms_page = raw_page.loc[raw_page.present_in_allow_list]\n",
+    "            unsanitized_unallowlisted_terms = raw_page.loc[~raw_page.present_in_allow_list]\n",
+    "\n",
+    "            pii_in_query_mask, run_data, language_data = await detect_pii(unsanitized_unallowlisted_terms['query'], census_surnames)\n",
+    "            sanitized_page = unsanitized_unallowlisted_terms.loc[~numpy.array(pii_in_query_mask)] # ~ reverses the mask so we get the queries WITHOUT PII in them\n",
+    "            total_allow_listed += allow_listed_terms_page.shape[0]\n",
+    "            total_cleared_in_sanitation += sanitized_page.shape[0]\n",
+    "        \n",
+    "            summary_language_data = dict(functools.reduce(operator.add,\n",
     "                            map(collections.Counter, [summary_language_data, language_data])))\n",
-    "        summary_run_data = dict(functools.reduce(operator.add,\n",
+    "            summary_run_data = dict(functools.reduce(operator.add,\n",
     "                            map(collections.Counter, [summary_run_data, run_data])))\n",
     "                \n",
-    "        all_terms_to_keep = pd.concat([allow_listed_terms_page, sanitized_page])\n",
-    "        all_terms_to_keep = all_terms_to_keep.drop(columns=['present_in_allow_list'])\n",
+    "            all_terms_to_keep = pd.concat([allow_listed_terms_page, sanitized_page])\n",
+    "            all_terms_to_keep = all_terms_to_keep.drop(columns=['present_in_allow_list'])\n",
     "        \n",
-    "        export_search_queries_to_bigquery(dataframe=all_terms_to_keep, destination_table_id=args.sanitized_term_destination, date=yesterday)\n",
+    "            export_search_queries_to_bigquery(dataframe=all_terms_to_keep, destination_table_id=args.sanitized_term_destination, date=yesterday)\n",
     "    \n",
-    "    end_time = datetime.utcnow()\n",
+    "        end_time = datetime.utcnow()\n",
     "    \n",
-    "    data_validation_sample = data_validation_sample.drop(columns=['present_in_allow_list'])\n",
-    "    export_sample_to_bigquery(dataframe=data_validation_sample, sample_table_id=args.unsanitized_term_sample_destination, date=yesterday)\n",
+    "        data_validation_sample = data_validation_sample.drop(columns=['present_in_allow_list'])\n",
+    "        export_sample_to_bigquery(dataframe=data_validation_sample, sample_table_id=args.unsanitized_term_sample_destination, date=yesterday)\n",
     "    \n",
-    "    implementation_notes = \"Run with a page_size of UNLIMITED from script\" \n",
-    "    record_job_metadata(status='SUCCESS', started_at=start_time, ended_at=end_time, destination_table=args.job_reporting_destination, total_run=total_run, total_allow_listed=total_allow_listed, total_rejected=total_run - total_deemed_sanitary, run_data=summary_run_data, language_data=summary_language_data, implementation_notes=implementation_notes)\n",
-    "except Exception as e:\n",
-    "    # TODO: Make this more robust in actual failure cases\n",
-    "    # Maybe include the reason? Or should the logs be elsewhere for that\n",
-    "    record_job_metadata(status='FAILURE', started_at=start_time, ended_at=datetime.utcnow(), destination_table=args.job_reporting_destination, failure_reason=str(e))\n",
-    "    raise e"
+    "        implementation_notes = \"Run with a page_size of UNLIMITED from script\" \n",
+    "        record_job_metadata(status='SUCCESS', started_at=start_time, ended_at=end_time, destination_table=args.job_reporting_destination, total_run=total_run, total_allow_listed=total_allow_listed, total_rejected=total_run - (total_allow_listed + total_cleared_in_sanitation), run_data=summary_run_data, language_data=summary_language_data, implementation_notes=implementation_notes)\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        # TODO: Make this more robust in actual failure cases\n",
+    "        # Maybe include the reason? Or should the logs be elsewhere for that\n",
+    "        record_job_metadata(status='FAILURE', started_at=start_time, ended_at=datetime.utcnow(),\n",
+    "                            destination_table=args.job_reporting_destination, failure_reason=str(e))\n",
+    "        raise e\n",
+    "\n",
+    "await run_sanitation(args)"
    ]
   },
   {

--- a/nightly-job/nightly-sanitization-pipeline.ipynb
+++ b/nightly-job/nightly-sanitization-pipeline.ipynb
@@ -171,7 +171,7 @@
     "\n",
     "        pii_in_query_mask, run_data, language_data = await detect_pii(unsanitized_unallowlisted_terms['query'], census_surnames)\n",
     "        sanitized_page = unsanitized_unallowlisted_terms.loc[~numpy.array(pii_in_query_mask)] # ~ reverses the mask so we get the queries WITHOUT PII in them\n",
-    "        total_deemed_sanitary += sanitized_page.shape[0]\n",
+    "        total_deemed_sanitary += (sanitized_page.shape[0] + allow_listed_terms_page.shape[0])\n",
     "        \n",
     "        summary_language_data = dict(functools.reduce(operator.add,\n",
     "                            map(collections.Counter, [summary_language_data, language_data])))\n",

--- a/nightly-job/nightly-sanitization-pipeline.ipynb
+++ b/nightly-job/nightly-sanitization-pipeline.ipynb
@@ -62,7 +62,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[]]\n"
+      "DATAFRAME COLS AT EXPORT\n",
+      "Index(['timestamp', 'request_id', 'session_id', 'sequence_no', 'query',\n",
+      "       'country', 'region', 'dma', 'form_factor', 'browser', 'os_family'],\n",
+      "      dtype='object')\n",
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
      ]
     },
     {
@@ -76,7 +80,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[]]\n"
+      "DATAFRAME COLS AT EXPORT\n",
+      "Index(['timestamp', 'request_id', 'session_id', 'sequence_no', 'query',\n",
+      "       'country', 'region', 'dma', 'form_factor', 'browser', 'os_family'],\n",
+      "      dtype='object')\n",
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
      ]
     },
     {
@@ -90,7 +98,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[]]\n"
+      "DATAFRAME COLS AT EXPORT\n",
+      "Index(['timestamp', 'request_id', 'session_id', 'sequence_no', 'query',\n",
+      "       'country', 'region', 'dma', 'form_factor', 'browser', 'os_family'],\n",
+      "      dtype='object')\n",
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
      ]
     },
     {
@@ -104,7 +116,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[]]\n"
+      "DATAFRAME COLS AT EXPORT\n",
+      "Index(['timestamp', 'request_id', 'session_id', 'sequence_no', 'query',\n",
+      "       'country', 'region', 'dma', 'form_factor', 'browser', 'os_family'],\n",
+      "      dtype='object')\n",
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
      ]
     },
     {
@@ -118,135 +134,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[]]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[]]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[]]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[]]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[]]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[]]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[]]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[]]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[]]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[]]\n",
-      "EXPORTING SAMPLE NOW\n",
-      "[[]]\n",
+      "DATAFRAME COLS AT EXPORT\n",
+      "Index(['timestamp', 'request_id', 'session_id', 'sequence_no', 'query',\n",
+      "       'country', 'region', 'dma', 'form_factor', 'browser', 'os_family'],\n",
+      "      dtype='object')\n",
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n",
+      "[[], [], []]\n",
       "New row representing job run successfully added.\n"
      ]
     }
@@ -272,9 +165,12 @@
     "        \n",
     "        one_percent_sample = raw_page.sample(frac = 0.01)\n",
     "        data_validation_sample = data_validation_sample.append(one_percent_sample)\n",
+    "        \n",
+    "        allow_listed_terms_page = raw_page.loc[raw_page.present_in_allow_list]\n",
+    "        unsanitized_unallowlisted_terms = raw_page.loc[~raw_page.present_in_allow_list]\n",
     "\n",
-    "        pii_in_query_mask, run_data, language_data = await detect_pii(raw_page['query'], census_surnames)\n",
-    "        sanitized_page = raw_page.loc[~numpy.array(pii_in_query_mask)] # ~ reverses the mask so we get the queries WITHOUT PII in them\n",
+    "        pii_in_query_mask, run_data, language_data = await detect_pii(unsanitized_unallowlisted_terms['query'], census_surnames)\n",
+    "        sanitized_page = unsanitized_unallowlisted_terms.loc[~numpy.array(pii_in_query_mask)] # ~ reverses the mask so we get the queries WITHOUT PII in them\n",
     "        total_deemed_sanitary += sanitized_page.shape[0]\n",
     "        \n",
     "        summary_language_data = dict(functools.reduce(operator.add,\n",
@@ -282,10 +178,14 @@
     "        summary_run_data = dict(functools.reduce(operator.add,\n",
     "                            map(collections.Counter, [summary_run_data, run_data])))\n",
     "                \n",
-    "        export_search_queries_to_bigquery(dataframe=sanitized_page, destination_table_id=args.sanitized_term_destination, date=yesterday)\n",
+    "        all_terms_to_keep = pd.concat([allow_listed_terms_page, sanitized_page])\n",
+    "        all_terms_to_keep = all_terms_to_keep.drop(columns=['present_in_allow_list'])\n",
+    "        \n",
+    "        export_search_queries_to_bigquery(dataframe=all_terms_to_keep, destination_table_id=args.sanitized_term_destination, date=yesterday)\n",
     "    \n",
     "    end_time = datetime.utcnow()\n",
     "    \n",
+    "    data_validation_sample = data_validation_sample.drop(columns=['present_in_allow_list'])\n",
     "    export_sample_to_bigquery(dataframe=data_validation_sample, sample_table_id=args.unsanitized_term_sample_destination, date=yesterday)\n",
     "    \n",
     "    implementation_notes = \"Run with a page_size of 300k\" \n",

--- a/nightly-job/nightly-sanitization-pipeline.ipynb
+++ b/nightly-job/nightly-sanitization-pipeline.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "ffc5aca5-bb6f-43ee-b865-a971ad38edc8",
    "metadata": {
     "tags": []
@@ -62,11 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DATAFRAME COLS AT EXPORT\n",
-      "Index(['timestamp', 'request_id', 'session_id', 'sequence_no', 'query',\n",
-      "       'country', 'region', 'dma', 'form_factor', 'browser', 'os_family'],\n",
-      "      dtype='object')\n",
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
      ]
     },
     {
@@ -80,10 +76,146 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DATAFRAME COLS AT EXPORT\n",
-      "Index(['timestamp', 'request_id', 'session_id', 'sequence_no', 'query',\n",
-      "       'country', 'region', 'dma', 'form_factor', 'browser', 'os_family'],\n",
-      "      dtype='object')\n",
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
      ]
     },
@@ -98,10 +230,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DATAFRAME COLS AT EXPORT\n",
-      "Index(['timestamp', 'request_id', 'session_id', 'sequence_no', 'query',\n",
-      "       'country', 'region', 'dma', 'form_factor', 'browser', 'os_family'],\n",
-      "      dtype='object')\n",
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
      ]
     },
@@ -116,10 +258,230 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DATAFRAME COLS AT EXPORT\n",
-      "Index(['timestamp', 'request_id', 'session_id', 'sequence_no', 'query',\n",
-      "       'country', 'region', 'dma', 'form_factor', 'browser', 'os_family'],\n",
-      "      dtype='object')\n",
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
      ]
     },
@@ -134,12 +496,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DATAFRAME COLS AT EXPORT\n",
-      "Index(['timestamp', 'request_id', 'session_id', 'sequence_no', 'query',\n",
-      "       'country', 'region', 'dma', 'form_factor', 'browser', 'os_family'],\n",
-      "      dtype='object')\n",
-      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n",
-      "[[], [], []]\n",
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning : `load_model` does not return WordVectorModel or SupervisedModel any more, but a `FastText` object which is very similar.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], []]\n",
+      "[[], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], []]\n",
       "New row representing job run successfully added.\n"
      ]
     }
@@ -152,6 +538,7 @@
     "\n",
     "try:\n",
     "    total_run = 0\n",
+    "    total_allow_listed = 0\n",
     "    total_deemed_sanitary = 0\n",
     "    summary_run_data = {}\n",
     "    summary_language_data = {}\n",
@@ -171,7 +558,8 @@
     "\n",
     "        pii_in_query_mask, run_data, language_data = await detect_pii(unsanitized_unallowlisted_terms['query'], census_surnames)\n",
     "        sanitized_page = unsanitized_unallowlisted_terms.loc[~numpy.array(pii_in_query_mask)] # ~ reverses the mask so we get the queries WITHOUT PII in them\n",
-    "        total_deemed_sanitary += (sanitized_page.shape[0] + allow_listed_terms_page.shape[0])\n",
+    "        total_allow_listed += allow_listed_terms_page.shape[0]\n",
+    "        total_deemed_sanitary += (sanitized_page.shape[0] + total_allow_listed)\n",
     "        \n",
     "        summary_language_data = dict(functools.reduce(operator.add,\n",
     "                            map(collections.Counter, [summary_language_data, language_data])))\n",
@@ -188,8 +576,8 @@
     "    data_validation_sample = data_validation_sample.drop(columns=['present_in_allow_list'])\n",
     "    export_sample_to_bigquery(dataframe=data_validation_sample, sample_table_id=args.unsanitized_term_sample_destination, date=yesterday)\n",
     "    \n",
-    "    implementation_notes = \"Run with a page_size of 300k\" \n",
-    "    record_job_metadata(status='SUCCESS', started_at=start_time, ended_at=end_time, destination_table=args.job_reporting_destination, total_run=total_run, total_rejected=total_run - total_deemed_sanitary, run_data=summary_run_data, language_data=summary_language_data, implementation_notes=implementation_notes)\n",
+    "    implementation_notes = \"Run with a page_size of UNLIMITED from script\" \n",
+    "    record_job_metadata(status='SUCCESS', started_at=start_time, ended_at=end_time, destination_table=args.job_reporting_destination, total_run=total_run, total_allow_listed=total_allow_listed, total_rejected=total_run - total_deemed_sanitary, run_data=summary_run_data, language_data=summary_language_data, implementation_notes=implementation_notes)\n",
     "except Exception as e:\n",
     "    # TODO: Make this more robust in actual failure cases\n",
     "    # Maybe include the reason? Or should the logs be elsewhere for that\n",

--- a/nightly-job/query_sanitization.py
+++ b/nightly-job/query_sanitization.py
@@ -110,23 +110,69 @@ async def mutate_risk(pii_risk, run_data, language_data, idx, query_info, census
             run_data['sum_terms_containing_us_census_surname'] += 1
             return
         
+PREAPPROVED_QUERIES_FROM_ALLOWLIST = """
+WITH approved_terms as (
+    SELECT
+    -- Each keyword should only appear once, but we add DISTINCT for protection
+    -- in downstream joins in case the suggestions file has errors.
+    DISTINCT query
+    FROM
+        `moz-fx-data-shared-prod.search_terms_derived.remotesettings_suggestions_v1`
+    CROSS JOIN
+    UNNEST(keywords) AS query
+    )
+
+SELECT
+    search_logs.timestamp AS timestamp,
+    search_logs.jsonPayload.fields.rid AS request_id,
+    search_logs.jsonPayload.fields.session_id AS session_id,
+    search_logs.jsonPayload.fields.sequence_no AS sequence_no,
+    search_logs.jsonPayload.fields.query AS query,
+    -- Merino currently injects 'none' for missing geo fields.
+    NULLIF(search_logs.jsonPayload.fields.country, 'none') AS country,
+    NULLIF(search_logs.jsonPayload.fields.region, 'none') AS region,
+    NULLIF(search_logs.jsonPayload.fields.dma, 'none') AS dma,
+    search_logs.jsonPayload.fields.form_factor AS form_factor,
+    search_logs.jsonPayload.fields.browser AS browser,
+    search_logs.jsonPayload.fields.os_family AS os_family
+FROM `suggest-searches-prod-a30f.logs.stdout` AS search_logs
+INNER JOIN approved_terms ON search_logs.jsonPayload.fields.query=approved_terms.query
+WHERE
+    jsonPayload.type = "web.suggest.request"
+    --Specifically get the previous day's data
+    AND timestamp >= DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL -1 DAY)
+    AND DATE(timestamp) < CURRENT_DATE()
+"""      
 
 UNSANITIZED_QUERIES_FOR_ANALYSIS_SQL = """
+WITH approved_terms as (
+    SELECT
+    -- Each keyword should only appear once, but we add DISTINCT for protection
+    -- in downstream joins in case the suggestions file has errors.
+    DISTINCT query
+    FROM
+        `moz-fx-data-shared-prod.search_terms_derived.remotesettings_suggestions_v1`
+    CROSS JOIN
+    UNNEST(keywords) AS query
+    )
+
 SELECT
-    timestamp AS timestamp,
-    jsonPayload.fields.rid AS request_id,
-    jsonPayload.fields.session_id,
-    jsonPayload.fields.sequence_no,
-    jsonPayload.fields.query,
+    search_logs.timestamp AS timestamp,
+    search_logs.jsonPayload.fields.rid AS request_id,
+    search_logs.jsonPayload.fields.session_id AS session_id,
+    search_logs.jsonPayload.fields.sequence_no AS sequence_no,
+    search_logs.jsonPayload.fields.query AS query,
     -- Merino currently injects 'none' for missing geo fields.
-    NULLIF(jsonPayload.fields.country, 'none') AS country,
-    NULLIF(jsonPayload.fields.region, 'none') AS region,
-    NULLIF(jsonPayload.fields.dma, 'none') AS dma,
-    jsonPayload.fields.form_factor AS form_factor,
-    jsonPayload.fields.browser AS browser,
-    jsonPayload.fields.os_family AS os_family
-FROM `suggest-searches-prod-a30f.logs.stdout`
-WHERE
+    NULLIF(search_logs.jsonPayload.fields.country, 'none') AS country,
+    NULLIF(search_logs.jsonPayload.fields.region, 'none') AS region,
+    NULLIF(search_logs.jsonPayload.fields.dma, 'none') AS dma,
+    search_logs.jsonPayload.fields.form_factor AS form_factor,
+    search_logs.jsonPayload.fields.browser AS browser,
+    search_logs.jsonPayload.fields.os_family AS os_family
+FROM `suggest-searches-prod-a30f.logs.stdout` AS search_logs
+LEFT JOIN approved_terms on search_logs.jsonPayload.fields.query = approved_terms.query
+WHERE approved_terms.query IS NULL
+AND
     jsonPayload.type = "web.suggest.request"
     --Specifically get the previous day's data
     AND timestamp >= DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL -1 DAY)

--- a/nightly-job/query_sanitization.py
+++ b/nightly-job/query_sanitization.py
@@ -261,7 +261,7 @@ def export_sample_to_bigquery(dataframe, sample_table_id, date):
     print(job)  # Wait for the job to complete.
 
 
-def record_job_metadata(status, started_at, ended_at, destination_table, total_run=0, total_rejected=0, run_data=None, language_data=None, failure_reason=None, implementation_notes=None):
+def record_job_metadata(status, started_at, ended_at, destination_table, total_run=0, total_allow_listed=0, total_rejected=0, run_data=None, language_data=None, failure_reason=None, implementation_notes=None):
     """
     Record metadata on a sanitation job run. There are two types of data:
     
@@ -276,6 +276,7 @@ def record_job_metadata(status, started_at, ended_at, destination_table, total_r
     - ended_at: When the job ended
     - destination_table: where to log the job info
     - total_run: number of search terms evaluated for sanitation
+    - total_allow_listed: number of search terms automatically deemed sanitary/saveable by appearing in an allow list
     - total_rejected: number of search terms deemed at risk of containing personally identifiable information
     - run_data: a Python dictionary with a variety of aggregate metrics in it about what was in the terms run
     - language_data: a Python dictionary counting the language categorizations for the terms run
@@ -294,6 +295,7 @@ def record_job_metadata(status, started_at, ended_at, destination_table, total_r
         {
          u"status": status, 
          u"total_search_terms_analyzed": total_run, 
+         u"total_search_terms_appearing_in_allow_list": total_allow_listed, 
          u"total_search_terms_removed_by_sanitization_job": total_rejected, 
          u"contained_numbers": run_data.get('num_terms_containing_numeral', 0),
          u"contained_at": run_data.get('num_terms_containing_at', 0),

--- a/nightly-job/sanitation_job.py
+++ b/nightly-job/sanitation_job.py
@@ -44,7 +44,7 @@ async def run_sanitation(args):
 
             pii_in_query_mask, run_data, language_data = await detect_pii(unsanitized_unallowlisted_terms['query'], census_surnames)
             sanitized_page = unsanitized_unallowlisted_terms.loc[~numpy.array(pii_in_query_mask)] # ~ reverses the mask so we get the queries WITHOUT PII in them
-            total_deemed_sanitary += sanitized_page.shape[0]
+            total_deemed_sanitary += (sanitized_page.shape[0] + allow_listed_terms_page.shape[0])
         
             summary_language_data = dict(functools.reduce(operator.add,
                             map(collections.Counter, [summary_language_data, language_data])))

--- a/nightly-job/sanitation_job.py
+++ b/nightly-job/sanitation_job.py
@@ -25,13 +25,14 @@ async def run_sanitation(args):
 
     try:
         total_run = 0
+        total_allow_listed = 0
         total_deemed_sanitary = 0
         summary_run_data = {}
         summary_language_data = {}
         yesterday = datetime.utcnow().date() - timedelta(days=1)
-        
+    
         data_validation_sample = pd.DataFrame()
-
+    
         unsanitized_search_term_stream = stream_search_terms() # load unsanitized search terms
         for raw_page in unsanitized_search_term_stream:
             total_run += raw_page.shape[0]
@@ -44,7 +45,8 @@ async def run_sanitation(args):
 
             pii_in_query_mask, run_data, language_data = await detect_pii(unsanitized_unallowlisted_terms['query'], census_surnames)
             sanitized_page = unsanitized_unallowlisted_terms.loc[~numpy.array(pii_in_query_mask)] # ~ reverses the mask so we get the queries WITHOUT PII in them
-            total_deemed_sanitary += (sanitized_page.shape[0] + allow_listed_terms_page.shape[0])
+            total_allow_listed += allow_listed_terms_page.shape[0]
+            total_deemed_sanitary += (sanitized_page.shape[0] + total_allow_listed)
         
             summary_language_data = dict(functools.reduce(operator.add,
                             map(collections.Counter, [summary_language_data, language_data])))
@@ -60,12 +62,10 @@ async def run_sanitation(args):
     
         data_validation_sample = data_validation_sample.drop(columns=['present_in_allow_list'])
         export_sample_to_bigquery(dataframe=data_validation_sample, sample_table_id=args.unsanitized_term_sample_destination, date=yesterday)
+    
+        implementation_notes = "Run with a page_size of UNLIMITED from script" 
+        record_job_metadata(status='SUCCESS', started_at=start_time, ended_at=end_time, destination_table=args.job_reporting_destination, total_run=total_run, total_allow_listed=total_allow_listed, total_rejected=total_run - total_deemed_sanitary, run_data=summary_run_data, language_data=summary_language_data, implementation_notes=implementation_notes)
 
-        implementation_notes = "Run with a page_size of UNLIMITED from script"
-        record_job_metadata(status='SUCCESS', started_at=start_time, ended_at=end_time,
-                            destination_table=args.job_reporting_destination, total_run=total_run,
-                            total_rejected=total_run - total_deemed_sanitary, run_data=summary_run_data,
-                            language_data=summary_language_data, implementation_notes=implementation_notes)
     except Exception as e:
         # TODO: Make this more robust in actual failure cases
         # Maybe include the reason? Or should the logs be elsewhere for that


### PR DESCRIPTION
We have implemented a search strategy here that identifies search terms as sanitary based on the absence of numerals, the @ symbol, or names.

We would, however, _also_ like to include all the terms that would have been approved by our _previous_ sanitization strategy, which was to compare them against an allow list that we stored in another table.

This change now preserves that behavior. So we will store all search terms for a longer period that lack numerals, the @ symbol, or names, _or_ appear in the sanitization allow list (this takes precedence: so something with a numeral that appears in the allow list would be marked sanitary). 

Lines 41-43 in the `.ipynb` file in the Files Changed list the names of the staging tables, which are in mozdata. Please feel free to check these tables to make sure that: 

- `mozdata.search_terms_unsanitized_analysis.prototype_sanitized_data` has search terms in it we would want to keep
- `mozdata.search_terms_unsanitized_analysis.prototype_sanitization_job_metadata` indicates a successful job run
- `mozdata.search_terms_unsanitized_analysis.prototype_unsanitized_sample_data` has the appropriate 1% sample

I have not done speed testing on this strategy, but it is the one that hits BQ the fewest separate times. I'd like to see how it fares on our dataset over the course of a few days and adjust if it's consistently coming in too slow before prematurely optimizing. 