### PR TITLE
Pin dockerfile python version to 3.10

### DIFF
--- a/nightly-job/Dockerfile
+++ b/nightly-job/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10
 
 WORKDIR /usr/app/src
 


### PR DESCRIPTION
`python:3` was pulling in 3.11 but we have dependencies that require python < 3.11. This change pins python 3.10 as the major version