### PR TITLE
Insert default value for 'None' on queries analyzed by spaCy

### DIFF
--- a/nightly-job/query_sanitization.py
+++ b/nightly-job/query_sanitization.py
@@ -32,7 +32,7 @@ async def detect_pii(series, census_surnames):
     language_data = {}
     
     # spaCy chokes when asked to evaluate 'None' instead of a text string
-    series.replace(None, "FX_RECEIVED_EMPTY_QUERY", inplace=True)
+    series.fillna("FX_RECEIVED_EMPTY_QUERY", inplace=True)
     texts = list(series)
     tasks = []
     

--- a/nightly-job/query_sanitization.py
+++ b/nightly-job/query_sanitization.py
@@ -31,6 +31,8 @@ async def detect_pii(series, census_surnames):
     }
     language_data = {}
     
+    # spaCy chokes when asked to evaluate 'None' instead of a text string
+    series.replace(None, "FX_RECEIVED_EMPTY_QUERY", inplace=True)
     texts = list(series)
     tasks = []
     

--- a/nightly-job/test_query_sanitization.py
+++ b/nightly-job/test_query_sanitization.py
@@ -1,5 +1,6 @@
 import pytest
 from query_sanitization import detect_pii
+import pandas as pd
 
 FAKE_CENSUS_SURNAMES = ["troy", "stuckey", "klukas", "burwei", "zeber", "reid", "dawson"] 
 
@@ -12,16 +13,16 @@ async def test_detect_pii_removes_numerals():
     Numerals are required to search for phone numbers or addresses, so
     we mark any search that contains them as a PII risk.
     """    
-    pii_risk, _, _ = await detect_pii(["2 cups of sugar"], FAKE_CENSUS_SURNAMES)
+    pii_risk, _, _ = await detect_pii(pd.Series(["2 cups of sugar"]), FAKE_CENSUS_SURNAMES)
     assert pii_risk == [True]
     
-    pii_risk, _, _ = await detect_pii(["two cups of sugar"], FAKE_CENSUS_SURNAMES)
+    pii_risk, _, _ = await detect_pii(pd.Series(["two cups of sugar"]), FAKE_CENSUS_SURNAMES)
     assert pii_risk == [False]
     
-    pii_risk, _, _ = await detect_pii(["912 Riverview Drive"], FAKE_CENSUS_SURNAMES)
+    pii_risk, _, _ = await detect_pii(pd.Series(["912 Riverview Drive"]), FAKE_CENSUS_SURNAMES)
     assert pii_risk == [True]
     
-    pii_risk, _, _ = await detect_pii(["Riverview Drive"], FAKE_CENSUS_SURNAMES)
+    pii_risk, _, _ = await detect_pii(pd.Series(["Riverview Drive"]), FAKE_CENSUS_SURNAMES)
     assert pii_risk == [False]
     
 @pytest.mark.asyncio
@@ -33,16 +34,16 @@ async def test_detect_pii_removes_at_symbol():
     The @ symbol appears in searches for email addresses or handles, so
     we mark any search that contains them as a PII risk.
     """    
-    pii_risk, _, _ = await detect_pii(["hi@hello.com"], FAKE_CENSUS_SURNAMES)
+    pii_risk, _, _ = await detect_pii(pd.Series(["hi@hello.com"]), FAKE_CENSUS_SURNAMES)
     assert pii_risk == [True]
     
-    pii_risk, _, _ = await detect_pii(["hi at hello dot com"], FAKE_CENSUS_SURNAMES)
+    pii_risk, _, _ = await detect_pii(pd.Series(["hi at hello dot com"]), FAKE_CENSUS_SURNAMES)
     assert pii_risk == [False]
     
-    pii_risk, _, _ = await detect_pii(["@mozilla on Twitter"], FAKE_CENSUS_SURNAMES)
+    pii_risk, _, _ = await detect_pii(pd.Series(["@mozilla on Twitter"]), FAKE_CENSUS_SURNAMES)
     assert pii_risk == [True]
     
-    pii_risk, _, _ = await detect_pii(["mozilla on Twitter"], FAKE_CENSUS_SURNAMES)
+    pii_risk, _, _ = await detect_pii(pd.Series(["mozilla on Twitter"]), FAKE_CENSUS_SURNAMES)
     assert pii_risk == [False]
     
 @pytest.mark.asyncio
@@ -59,12 +60,12 @@ async def test_detect_pii_marks_common_surnames():
     For now we do not remove them, because they contain a lot of
     words that are USUALLY not used as names, like 'black' or 'brown' or 'white'
     """    
-    _, run_data, _ = await detect_pii(["Will chelsea troy ever stop being a clown"], FAKE_CENSUS_SURNAMES)
+    _, run_data, _ = await detect_pii(pd.Series(["Will chelsea troy ever stop being a clown"]), FAKE_CENSUS_SURNAMES)
     assert run_data['sum_terms_containing_us_census_surname'] == 1
     
-    _, run_data, _ = await detect_pii(["The future of clowns"], FAKE_CENSUS_SURNAMES)
+    _, run_data, _ = await detect_pii(pd.Series(["The future of clowns"]), FAKE_CENSUS_SURNAMES)
     assert run_data['sum_terms_containing_us_census_surname'] == 0
     
     # Deliberately skips common surnames inside another word
-    _, run_data, _ = await detect_pii(["summer reiding program"], FAKE_CENSUS_SURNAMES)
+    _, run_data, _ = await detect_pii(pd.Series(["summer reiding program"]), FAKE_CENSUS_SURNAMES)
     assert run_data['sum_terms_containing_us_census_surname'] == 0    

--- a/nightly-job/test_query_sanitization.py
+++ b/nightly-job/test_query_sanitization.py
@@ -5,6 +5,15 @@ import pandas as pd
 FAKE_CENSUS_SURNAMES = ["troy", "stuckey", "klukas", "burwei", "zeber", "reid", "dawson"] 
 
 @pytest.mark.asyncio
+async def test_detect_pii_replaces_none():
+    """
+    spaCy hates it when we pass `None` instead of a string for analysis, apparently.
+    This test ensures that our function doesn't error out on that edge case.
+    """    
+    pii_risk, _, _ = await detect_pii(pd.Series([None]), FAKE_CENSUS_SURNAMES)
+    assert pii_risk == [False] 
+
+@pytest.mark.asyncio
 async def test_detect_pii_removes_numerals():
     """
     Currently, we use rules to determine which search terms 


### PR DESCRIPTION
Since November 30, the search term sanitization script has usually been failing each day with the following error" 

`[E1041] Expected a string, Doc, or bytes as input, but got: <class 'NoneType'>`.

I was unable to replicate the error in the staging environment: when I went into Vertex AI and ran `[search-terms-sanitization/nightly-job/mimic-production-tables-in-mozdata.ipynb](https://github.com/mozilla/search-terms-sanitization/blob/main/nightly-job/mimic-production-tables-in-mozdata.ipynb), it succeeded. 

Some research indicates that this happens when spaCy encounters 'None' as an input to its `nlp()` function. 
Research:
- I googled the error message
- I opened a new cell in a Jupyter notebook and specifically ran the function on a list of strings that included some `None` values and got the error message.

I don't think this is new spaCy behavior that is breaking us now because we failed to lock a version. Why:
- This started happening 8 days ago. The most recent upversion for spaCy that fell inside our version bracket was 27 days ago. 

So my suspicion is that something changed in the way we are collecting or storing search queries that allows something to get recorded as `None` that used to not get recorded that way.

I tried to confirm that hypothesis, first by checking the unsanitized data table that covers the last 48 hours. Indeed, I found 3 rows in there where the query field is `null`. 

Unfortunately, I cannot check further than this. In theory I should be able to query the unsanitized _sample_ table and see whether `null` in a query in a new thing since November 30. However, in my infinite wisdom, I organized the code such that this sample only gets recorded if the job succeeds. 

This PR does two things:

1. It changes the organization of the script to store the sample, even if there is an exception in the rest of the code.
2. It replaces all `query` values of `None` with a recognizable sample string. I did this so that these values do not become indistinguishable from some existing precedent or meaning stored in empty string queries. 